### PR TITLE
Use headers to get image type

### DIFF
--- a/src/struct/post/embed/util.ts
+++ b/src/struct/post/embed/util.ts
@@ -104,8 +104,8 @@ export async function fetchImageForBlob(
 
 	const blob = await res.blob();
 	if (!blob) return null;
-
-	const { type } = blob;
+	
+	const type = res.headers.get("content-type");
 	if (!type?.startsWith("image/")) return null;
 
 	return { type, data: new Uint8Array(await blob.arrayBuffer()) };


### PR DESCRIPTION
I was testing and `fetchImageForBlob` always returned null, beacuse type was an empty string.

This fixes it for me locally