### PR TITLE
Add chat emitter options

### DIFF
--- a/src/bot/Bot.ts
+++ b/src/bot/Bot.ts
@@ -86,7 +86,7 @@ export interface BotOptions {
 	/** Options for the event emitter. */
 	eventEmitterOptions?: BotEventEmitterOptions;
 
-	/** Options for the chat emitter. If this isn't set, the bot will use `eventEmitterOptions`. */
+	/** Options for the chat emitter. If this isn't set, the bot will use {@link eventEmitterOptions}. */
 	chatEmitterOptions?: BotChatEmitterOptions;
 }
 

--- a/src/bot/Bot.ts
+++ b/src/bot/Bot.ts
@@ -42,7 +42,7 @@ import { type IncomingChatPreference, Profile } from "../struct/Profile.js";
 import { StarterPack } from "../struct/StarterPack.js";
 import { asDid } from "../util/lexicon.js";
 import { parseAtUri } from "../util/parseAtUri.js";
-import { BotChatEmitter } from "./BotChatEmitter.js";
+import { BotChatEmitter, type BotChatEmitterOptions } from "./BotChatEmitter.js";
 import { BotEventEmitter, type BotEventEmitterOptions, EventStrategy } from "./BotEventEmitter.js";
 import { type CacheOptions, makeCache } from "./cache.js";
 import { RateLimitedAgent } from "./RateLimitedAgent.js";
@@ -85,6 +85,9 @@ export interface BotOptions {
 
 	/** Options for the event emitter. */
 	eventEmitterOptions?: BotEventEmitterOptions;
+
+	/** Options for the chat emitter. If this isn't set, the bot will use `eventEmitterOptions`. */
+	chatEmitterOptions?: BotChatEmitterOptions;
 }
 
 /**
@@ -128,6 +131,7 @@ export class Bot extends EventEmitter {
 			rateLimitOptions,
 			cacheOptions,
 			eventEmitterOptions = { strategy: EventStrategy.Polling },
+			chatEmitterOptions,
 		}: BotOptions = {},
 	) {
 		super();
@@ -164,7 +168,7 @@ export class Bot extends EventEmitter {
 		}
 
 		if (emitChatEvents) {
-			this.chatEventEmitter = new BotChatEmitter(eventEmitterOptions, this);
+			this.chatEventEmitter = new BotChatEmitter(chatEmitterOptions ?? eventEmitterOptions, this);
 			this.chatEventEmitter.on("message", (event) => this.emit("message", event));
 			this.chatEventEmitter.on("error", (error) => this.emit("error", error));
 		}


### PR DESCRIPTION
There's no way to set specific chat emitter options without also setting event emitter options. This PR adds a separate configuration option when creating a `new Bot`. This is fully new functionality; if the user doesn't set `chatEmitterOptions`, everything will operate exactly the same (i.e. `eventEmitterOptions` will be sent to `new BotChatEmitter`).