### PR TITLE
fix several URL bug

### DIFF
--- a/src/richtext/detectFacets.ts
+++ b/src/richtext/detectFacets.ts
@@ -113,6 +113,7 @@ export function detectFacetsWithoutResolution(
 				text = text.slice(0, index.start) + shortenedUri + text.slice(index.end);
 				const lengthDifference = uri.length - shortenedUri.length;
 				index.end -= lengthDifference;
+				re.lastIndex -= lengthDifference; // Make it continue from the new url end index. Otherwise it might skip a second URL if the previous one was very long.
 			}
 
 			facets.push({


### PR DESCRIPTION
If you don't do this you might skip a second (or more) URL since you shortened the previous one in the "text" displacing the rest of the text and the "re" next iteration will start searching from the wrong place.