### PR TITLE
Add reply_root event

### DIFF
--- a/src/bot/Bot.ts
+++ b/src/bot/Bot.ts
@@ -160,6 +160,7 @@ export class Bot extends EventEmitter {
 			this.eventEmitter.on("error", (error) => this.emit("error", error));
 			this.eventEmitter.on("close", () => this.emit("close"));
 			this.eventEmitter.on("reply", (event) => this.emit("reply", event));
+			this.eventEmitter.on("reply_root", (event) => this.emit("reply_root", event));
 			this.eventEmitter.on("quote", (event) => this.emit("quote", event));
 			this.eventEmitter.on("mention", (event) => this.emit("mention", event));
 			this.eventEmitter.on("repost", (event) => this.emit("repost", event));
@@ -1522,6 +1523,8 @@ export class Bot extends EventEmitter {
 	override on(event: "close", listener: () => void): this;
 	/** Emitted when the bot receives a reply. */
 	override on(event: "reply", listener: (post: Post) => void): this;
+	/** Emitted when the bot receives a reply inside a post thread initiated by the bot. */
+	override on(event: "reply_root", listener: (post: Post) => void): this;
 	/** Emitted when the bot receives a quote post. */
 	override on(event: "quote", listener: (post: Post) => void): this;
 	/** Emitted when the bot is mentioned. */
@@ -1573,6 +1576,7 @@ export class Bot extends EventEmitter {
 	override addListener(event: "error", listener: (error: unknown) => void): this;
 	override addListener(event: "close", listener: () => void): this;
 	override addListener(event: "reply", listener: (post: Post) => void): this;
+	override addListener(event: "reply_root", listener: (post: Post) => void): this;
 	override addListener(event: "quote", listener: (post: Post) => void): this;
 	override addListener(event: "mention", listener: (post: Post) => void): this;
 	override addListener(

--- a/src/bot/BotEventEmitter.ts
+++ b/src/bot/BotEventEmitter.ts
@@ -253,16 +253,18 @@ export class BotEventEmitter extends EventEmitter {
 			"app.bsky.feed.post",
 			async ({ commit: { record, rkey }, did }) => {
 				const uri = `at://${did}/app.bsky.feed.post/${rkey}`;
-				if (record.reply?.parent?.uri?.includes(`at://${this.bot.profile.did}`)) {
+				if (record.reply?.parent?.uri?.startsWith(`at://${this.bot.profile.did}/`)) {
 					this.emit("reply", await this.bot.getPost(uri));
+				} else if (record.reply?.root?.uri?.startsWith(`at://${this.bot.profile.did}/`)) {
+					this.emit("reply_root", await this.bot.getPost(uri));
 				} else if (
 					is("app.bsky.embed.record", record.embed)
-					&& record.embed.record.uri.includes(`at://${this.bot.profile.did}`)
+					&& record.embed.record.uri.startsWith(`at://${this.bot.profile.did}/`)
 				) {
 					this.emit("quote", await this.bot.getPost(uri));
 				} else if (
 					is("app.bsky.embed.recordWithMedia", record.embed)
-					&& record.embed.record.record.uri.includes(`at://${this.bot.profile.did}`)
+					&& record.embed.record.record.uri.startsWith(`at://${this.bot.profile.did}/`)
 				) {
 					this.emit("quote", await this.bot.getPost(uri));
 				} else if (
@@ -282,7 +284,7 @@ export class BotEventEmitter extends EventEmitter {
 			"app.bsky.feed.repost",
 			async ({ commit: { record, rkey }, did }) => {
 				const uri = `at://${did}/app.bsky.feed.repost/${rkey}`;
-				if (record.subject?.uri?.includes(`at://${this.bot.profile.did}`)) {
+				if (record.subject?.uri?.startsWith(`at://${this.bot.profile.did}/`)) {
 					this.emit("repost", {
 						post: await this.bot.getPost(uri),
 						user: await this.bot.getProfile(did),
@@ -296,7 +298,7 @@ export class BotEventEmitter extends EventEmitter {
 			"app.bsky.feed.like",
 			async ({ commit: { record, rkey }, did }) => {
 				const uri = `at://${did}/app.bsky.feed.like/${rkey}`;
-				if (record.subject?.uri?.includes(`at://${this.bot.profile.did}`)) {
+				if (record.subject?.uri?.startsWith(`at://${this.bot.profile.did}/`)) {
 					const { collection, host } = parseAtUri(record.subject.uri);
 					let subject: Post | FeedGenerator | Labeler | undefined;
 					switch (collection) {


### PR DESCRIPTION
I wanted my bot to be able to intercept all replies made below its own posts, regardless of their parent-post.

This PR adds the ability to listen to those kind of replies, without interfering with the `reply` event, and without duplicate issues since `reply` takes precedence.

Possible problems: it will take precedence over `quote` & `mention` if someone happens to quote/mention the bot account in a reply inside a thread initiated by the bot. Note: The same behavior was already happening with the `reply` event.

I implemented the event into the polling interceptor as well. I took care to still ignore non-direct replies which are made to threads not initiated by the bot: it can happen when the bot has participated inside a thread and someone replies to a replying post.

Other minor fixes: I replaced `includes` with `startsWith` (it's more appropriate to what it's supposed to do, and it's [way more efficient](https://jsperf.app/zunivi); we're inside a Jetstream event handler so it does matter). I also added a `/` after the did, because, apart from [PLC DIDs](https://web.plc.directory/spec/v0.1/did-plc#:~:text=the%20overall%20identifier%20length%20is%2032%20characters), [they do not have a fixed length](https://atproto.com/specs/did#at-protocol-did-identifier-syntax:~:text=DID%20identifiers%20do%20not%20generally%20have%20a%20maximum%20length%20restriction%2C%20but%20in%20the%20context%20of%20atproto%2C%20there%20is%20an%20initial%20hard%20limit%20of%202%20KB.).

I am opened to any suggestion, including about the event name, I didn't find any naming convention. I could have used a hyphen instead of an underscore. Please suggest away if you happen to think of a better event name. Btw, edits by maintainers are allowed.